### PR TITLE
Bump version: 0.1.1 → 0.1.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r") as fh:
 setup(
     name="reviews",
     packages=find_namespace_packages(include=["reviews.*"]),
-    version="0.1.0",
+    version="0.1.2",
     license="MIT",
     description=("Code Review Manager written in Python. Standalone client included."),
     author="Kyle Harrison",


### PR DESCRIPTION
### What's Changed

Releases version `0.1.2` on https://pypi.org/project/reviews/

### Release process

Currently, the release process is manual

```bash
sudo rm -rf dist build
bumpversion patch setup.py
sudo python setup.py sdist bdist_wheel
twine check dist/*
twine upload --skip-existing --repository-url https://upload.pypi.org/legacy/ dist/* --verbose
```

### Release Notes

* Improves windows support in #43 
* Adds `CONTRIBUTING.md` in #43 